### PR TITLE
Add the option to launch tmc-cli from the plugin

### DIFF
--- a/src/testmycode.cpp
+++ b/src/testmycode.cpp
@@ -3,19 +3,49 @@
 
 #include <ui_loginscreen.h>
 
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QJsonDocument>
+
+#include <QApplication>
+#include <QDebug>
+
 #include <coreplugin/icore.h>
 #include <coreplugin/icontext.h>
 #include <coreplugin/actionmanager/actionmanager.h>
 #include <coreplugin/actionmanager/command.h>
 #include <coreplugin/actionmanager/actioncontainer.h>
 #include <coreplugin/coreconstants.h>
+#include <coreplugin/shellcommand.h>
+
+#include <projectexplorer/projectexplorer.h>
+#include <projectexplorer/project.h>
+#include <projectexplorer/session.h>
+#include <projectexplorer/target.h>
+
+#include <utils/fileutils.h>
+#include <utils/hostosinfo.h>
+#include <utils/environment.h>
+#include <utils/shellcommand.h>
 
 #include <QAction>
 #include <QMessageBox>
 #include <QMainWindow>
 #include <QMenu>
+#include <QObject>
+#include <QString>
+#include <QCoreApplication>
+#include <QProcessEnvironment>
+#include <QFileInfo>
+
+#include <QAction>
+#include <QCoreApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QByteArray>
 
 #include <QtPlugin>
+#include <extensionsystem/pluginmanager.h>
 
 using namespace TestMyCodePlugin::Internal;
 
@@ -44,20 +74,30 @@ bool TestMyCode::initialize(const QStringList &arguments, QString *errorString)
 
     Q_UNUSED(arguments)
     Q_UNUSED(errorString)
+    auto tmcAction = new QAction(tr("Test project"), this);
+    Core::Command *tmcCmd = Core::ActionManager::registerAction(tmcAction, Constants::TMC_ACTION_ID,
+                                                             Core::Context(Core::Constants::C_GLOBAL));
 
-    auto action = new QAction(tr("Login"), this);
-    Core::Command *cmd = Core::ActionManager::registerAction(action, Constants::ACTION_ID,
+    auto loginAction = new QAction(tr("Login"), this);
+    Core::Command *loginCmd = Core::ActionManager::registerAction(loginAction, Constants::LOGIN_ACTION_ID,
                                                              Core::Context(Core::Constants::C_GLOBAL));
     // Shortcut
-    // cmd->setDefaultKeySequence(QKeySequence(tr("Ctrl+K")));
-    connect(action, &QAction::triggered, this, &TestMyCode::showLoginWidget);
+    tmcCmd->setDefaultKeySequence(QKeySequence(tr("Alt+Shift+T")));
+    loginCmd->setDefaultKeySequence(QKeySequence(tr("Alt+L")));
+
+    connect(loginAction, &QAction::triggered, this, &TestMyCode::showLoginWidget);
+    connect(tmcAction, &QAction::triggered, this, &TestMyCode::runOnActiveProject);
 
     Core::ActionContainer *menu = Core::ActionManager::createMenu(Constants::MENU_ID);
 
     menu->menu()->setTitle(tr("TestMyCode"));
-    menu->addAction(cmd);
-
     Core::ActionManager::actionContainer(Core::Constants::M_TOOLS)->addMenu(menu);
+    menu->addAction(tmcCmd);
+    menu->addAction(loginCmd);
+
+    // Add TestMyCode between Tools and Window in the upper menu
+    auto tools_menu = Core::ActionManager::actionContainer(Core::Constants::M_WINDOW);
+    Core::ActionManager::actionContainer(Core::Constants::MENU_BAR)->addMenu(tools_menu, menu);
 
     // Initialize login window
     loginWidget = new QWidget;
@@ -90,15 +130,93 @@ void TestMyCode::showLoginWidget()
     loginWidget->show();
 }
 
-} // namespace Internal
-} // namespace TestMyCodePlugin
+void TestMyCode::runOnActiveProject()
+{
+    ProjectExplorer::Project *project = ProjectExplorer::SessionManager::startupProject();
+    if (!project) {
+        QMessageBox::information(Core::ICore::mainWindow(), tr("No project"), tr("No active project"));
+        return;
+    }
+    QString path = project->projectFilePath().parentDir().toString();
+    launchTmcCLI(path);
+}
 
-void TestMyCodePlugin::Internal::TestMyCode::on_cancelbutton_clicked()
+void TestMyCode::launchTmcCLI(const QString &workingDirectory)
+{
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    QString tmc_cli = env.value("TMC_CLI", "/opt/tmc_cli.jar");
+
+    QString testOutput = workingDirectory + "/out.txt";
+    QStringList arguments;
+    arguments << "-jar" << tmc_cli;
+    arguments << "run-tests";
+    arguments << "--exercisePath" << workingDirectory;
+    arguments << "--outputPath" << testOutput;
+    QMessageBox::information(Core::ICore::mainWindow(), tr("launching"), tr("%1").arg(arguments.join(QString(" "))));
+    // TODO: make work in windows
+    const Utils::FileName java = Utils::FileName().fromString("/usr/bin/java");
+
+    Core::ShellCommand command(workingDirectory, env);
+
+    Utils::SynchronousProcessResponse response
+         = command.runCommand(java, arguments, 1500, workingDirectory, Utils::defaultExitCodeInterpreter);
+
+    QMessageBox::information(Core::ICore::mainWindow(), tr("TMC CLI output"), tr("%1").arg(response.allOutput()));
+
+    QString output = readTMCOutput(testOutput);
+}
+
+/*
+   TMC CLI output format is JSON,
+   where compiler / stacktrace output is in integers representing characters:
+
+  {
+    "status": "COMPILE_FAILED",
+    "testResults": [],
+    "logs": {
+      "compiler_output": [
+        [109,97,107,101,58,32,42,42,42,32,78 ...]
+    }
+  }
+
+*/
+QString TestMyCode::readTMCOutput(const QString &testOutput)
+{
+    QFile file(testOutput);
+    if(!file.open(QIODevice::ReadOnly)) {
+        QMessageBox::information(0, "error", file.errorString());
+    }
+
+    QByteArray rawData = file.readAll();
+    QJsonDocument doc(QJsonDocument::fromJson(rawData));
+
+    QJsonObject json = doc.object();
+    const QString status = json["status"].toString();
+    const QJsonObject logs = json["logs"].toObject();
+
+    // Convert integers back to a string
+    const QJsonArray compiler_output = logs["compiler_output"].toArray();
+    QString compiler_output_str;
+    foreach (QJsonValue character, compiler_output) {
+        compiler_output_str.append(character.toInt());
+    }
+
+    file.close();
+
+    QMessageBox::information(Core::ICore::mainWindow(), tr("%1").arg(status), tr("%1").arg(compiler_output_str));
+
+    return compiler_output_str;
+}
+
+void TestMyCode::on_cancelbutton_clicked()
 {
     loginWidget->close();
 }
 
-void TestMyCodePlugin::Internal::TestMyCode::on_loginbutton_clicked()
+void TestMyCode::on_loginbutton_clicked()
 {
     // TODO: Authentication
 }
+
+} // namespace Internal
+} // namespace TestMyCodePlugin

--- a/src/testmycode.h
+++ b/src/testmycode.h
@@ -4,6 +4,25 @@
 #include <extensionsystem/iplugin.h>
 #include <QWidget>
 
+#include <projectexplorer/project.h>
+#include <projectexplorer/projectexplorer.h>
+#include <projectexplorer/session.h>
+#include <projectexplorer/target.h>
+
+#include <extensionsystem/iplugin.h>
+#include <utils/hostosinfo.h>
+#include <utils/fileutils.h>
+
+#include <QAction>
+#include <QMessageBox>
+#include <QMainWindow>
+#include <QMenu>
+#include <QObject>
+#include <QString>
+#include <QCoreApplication>
+#include <QProcessEnvironment>
+#include <QFileInfo>
+
 namespace TestMyCodePlugin {
 namespace Internal {
 
@@ -29,6 +48,17 @@ private:
     Ui::loginform *login;
     QWidget *loginWidget;
     void showLoginWidget();
+    void runOnActiveProject();
+
+    void triggerAction();
+    void launchTmcCLI(const QString &workingDirectory);
+    bool tryLauchingTmcCLI(const QProcessEnvironment &env,
+                                    const QString &workingDirectory);
+    Utils::FileName tmcBinary() const;
+    QProcessEnvironment processEnvironment() const;
+    QStringList searchPathList() const;
+    void onCurrentProjectChanged(ProjectExplorer::Project *project);
+    QString readTMCOutput(const QString &testOutput);
 };
 
 } // namespace Internal

--- a/src/testmycodeconstants.h
+++ b/src/testmycodeconstants.h
@@ -3,7 +3,9 @@
 namespace TestMyCodePlugin {
 namespace Constants {
 
-const char ACTION_ID[] = "TestMyCodePlugin.Action";
+const char TMC_ACTION_ID[] = "TestMyCodePlugin.Action.TMC";
+const char LOGIN_ACTION_ID[] = "TestMyCodePlugin.Action.Login";
+
 const char MENU_ID[] = "TestMyCodePlugin.Menu";
 
 } // namespace TestMyCodePlugin


### PR DESCRIPTION
- Runs tmc-cli jar with java (hardcoded for now)
- Parses test output json from tmc-cli
- Displays the result in QMessageBox