### PR TITLE
Output pane for TMC CLI test output

### DIFF
--- a/src/testmycode.cpp
+++ b/src/testmycode.cpp
@@ -1,12 +1,10 @@
 #include "testmycode.h"
 #include "testmycodeconstants.h"
 #include "tmcclient.h"
+#include "tmcoutputpane.h"
+#include "tmcrunner.h"
 
 #include <ui_loginscreen.h>
-
-#include <QJsonObject>
-#include <QJsonArray>
-#include <QJsonDocument>
 
 #include <QApplication>
 #include <QDebug>
@@ -17,17 +15,6 @@
 #include <coreplugin/actionmanager/command.h>
 #include <coreplugin/actionmanager/actioncontainer.h>
 #include <coreplugin/coreconstants.h>
-#include <coreplugin/shellcommand.h>
-
-#include <projectexplorer/projectexplorer.h>
-#include <projectexplorer/project.h>
-#include <projectexplorer/session.h>
-#include <projectexplorer/target.h>
-
-#include <utils/fileutils.h>
-#include <utils/hostosinfo.h>
-#include <utils/environment.h>
-#include <utils/shellcommand.h>
 
 #include <QAction>
 #include <QMessageBox>
@@ -35,10 +22,6 @@
 #include <QMenu>
 #include <QObject>
 #include <QString>
-#include <QCoreApplication>
-#include <QProcessEnvironment>
-#include <QFileInfo>
-
 #include <QAction>
 #include <QCoreApplication>
 #include <QDir>
@@ -89,7 +72,7 @@ bool TestMyCode::initialize(const QStringList &arguments, QString *errorString)
     loginCmd->setDefaultKeySequence(QKeySequence(tr("Alt+L")));
 
     connect(loginAction, &QAction::triggered, this, &TestMyCode::showLoginWidget);
-    connect(tmcAction, &QAction::triggered, this, &TestMyCode::runOnActiveProject);
+    connect(tmcAction, &QAction::triggered, this, &TestMyCode::runTMC);
 
     Core::ActionContainer *menu = Core::ActionManager::createMenu(Constants::MENU_ID);
 
@@ -101,6 +84,8 @@ bool TestMyCode::initialize(const QStringList &arguments, QString *errorString)
     // Add TestMyCode between Tools and Window in the upper menu
     auto tools_menu = Core::ActionManager::actionContainer(Core::Constants::M_WINDOW);
     Core::ActionManager::actionContainer(Core::Constants::MENU_BAR)->addMenu(tools_menu, menu);
+
+    addAutoReleasedObject(TmcOutputPane::instance());
 
     // Initialize login window
     loginWidget = new QWidget;
@@ -139,82 +124,9 @@ void TestMyCode::showLoginWidget()
     loginWidget->show();
 }
 
-void TestMyCode::runOnActiveProject()
-{
-    ProjectExplorer::Project *project = ProjectExplorer::SessionManager::startupProject();
-    if (!project) {
-        QMessageBox::information(Core::ICore::mainWindow(), tr("No project"), tr("No active project"));
-        return;
-    }
-    QString path = project->projectFilePath().parentDir().toString();
-    launchTmcCLI(path);
-}
-
-void TestMyCode::launchTmcCLI(const QString &workingDirectory)
-{
-    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-    QString tmc_cli = env.value("TMC_CLI", "/opt/tmc_cli.jar");
-
-    QString testOutput = workingDirectory + "/out.txt";
-    QStringList arguments;
-    arguments << "-jar" << tmc_cli;
-    arguments << "run-tests";
-    arguments << "--exercisePath" << workingDirectory;
-    arguments << "--outputPath" << testOutput;
-    QMessageBox::information(Core::ICore::mainWindow(), tr("launching"), tr("%1").arg(arguments.join(QString(" "))));
-    // TODO: make work in windows
-    const Utils::FileName java = Utils::FileName().fromString("/usr/bin/java");
-
-    Core::ShellCommand command(workingDirectory, env);
-
-    Utils::SynchronousProcessResponse response
-         = command.runCommand(java, arguments, 1500, workingDirectory, Utils::defaultExitCodeInterpreter);
-
-    QMessageBox::information(Core::ICore::mainWindow(), tr("TMC CLI output"), tr("%1").arg(response.allOutput()));
-
-    QString output = readTMCOutput(testOutput);
-}
-
-/*
-   TMC CLI output format is JSON,
-   where compiler / stacktrace output is in integers representing characters:
-
-  {
-    "status": "COMPILE_FAILED",
-    "testResults": [],
-    "logs": {
-      "compiler_output": [
-        [109,97,107,101,58,32,42,42,42,32,78 ...]
-    }
-  }
-
-*/
-QString TestMyCode::readTMCOutput(const QString &testOutput)
-{
-    QFile file(testOutput);
-    if(!file.open(QIODevice::ReadOnly)) {
-        QMessageBox::information(0, "error", file.errorString());
-    }
-
-    QByteArray rawData = file.readAll();
-    QJsonDocument doc(QJsonDocument::fromJson(rawData));
-
-    QJsonObject json = doc.object();
-    const QString status = json["status"].toString();
-    const QJsonObject logs = json["logs"].toObject();
-
-    // Convert integers back to a string
-    const QJsonArray compiler_output = logs["compiler_output"].toArray();
-    QString compiler_output_str;
-    foreach (QJsonValue character, compiler_output) {
-        compiler_output_str.append(character.toInt());
-    }
-
-    file.close();
-
-    QMessageBox::information(Core::ICore::mainWindow(), tr("%1").arg(status), tr("%1").arg(compiler_output_str));
-
-    return compiler_output_str;
+void TestMyCode::runTMC() {
+    TMCRunner *runner = TMCRunner::instance();
+    runner->runOnActiveProject();
 }
 
 void TestMyCode::on_cancelbutton_clicked()

--- a/src/testmycode.h
+++ b/src/testmycode.h
@@ -50,17 +50,9 @@ private:
     QWidget *loginWidget;
     void showLoginWidget();
     TmcClient tmcClient;
-    void runOnActiveProject();
+    void runTMC();
 
     void triggerAction();
-    void launchTmcCLI(const QString &workingDirectory);
-    bool tryLauchingTmcCLI(const QProcessEnvironment &env,
-                                    const QString &workingDirectory);
-    Utils::FileName tmcBinary() const;
-    QProcessEnvironment processEnvironment() const;
-    QStringList searchPathList() const;
-    void onCurrentProjectChanged(ProjectExplorer::Project *project);
-    QString readTMCOutput(const QString &testOutput);
 };
 
 } // namespace Internal

--- a/src/testmycodeconstants.h
+++ b/src/testmycodeconstants.h
@@ -8,5 +8,8 @@ const char LOGIN_ACTION_ID[] = "TestMyCodePlugin.Action.Login";
 
 const char MENU_ID[] = "TestMyCodePlugin.Menu";
 
+const char TASK_INDEX[] = "TestMyCodePlugin.Task.Index";
+
+
 } // namespace TestMyCodePlugin
 } // namespace Constants

--- a/src/testmycodeconstants.h
+++ b/src/testmycodeconstants.h
@@ -8,8 +8,5 @@ const char LOGIN_ACTION_ID[] = "TestMyCodePlugin.Action.Login";
 
 const char MENU_ID[] = "TestMyCodePlugin.Menu";
 
-const char TASK_INDEX[] = "TestMyCodePlugin.Task.Index";
-
-
 } // namespace TestMyCodePlugin
 } // namespace Constants

--- a/src/tmcoutputpane.cpp
+++ b/src/tmcoutputpane.cpp
@@ -1,0 +1,184 @@
+#include "tmcoutputpane.h"
+#include "tmcrunner.h"
+#include "tmcresultmodel.h"
+
+#include <aggregation/aggregate.h>
+#include <coreplugin/actionmanager/actionmanager.h>
+#include <coreplugin/coreconstants.h>
+#include <coreplugin/editormanager/editormanager.h>
+#include <coreplugin/find/basetextfind.h>
+#include <coreplugin/find/itemviewfind.h>
+#include <coreplugin/icontext.h>
+#include <coreplugin/icore.h>
+#include <projectexplorer/buildmanager.h>
+#include <projectexplorer/projectexplorer.h>
+#include <texteditor/texteditor.h>
+#include <utils/theme/theme.h>
+#include <utils/utilsicons.h>
+#include <utils/treemodel.h>
+
+#include <QApplication>
+#include <QClipboard>
+#include <QDebug>
+#include <QFileDialog>
+#include <QHBoxLayout>
+#include <QMenu>
+#include <QMessageBox>
+#include <QScrollBar>
+#include <QStackedWidget>
+#include <QToolButton>
+#include <QVBoxLayout>
+
+TmcOutputPane::TmcOutputPane(QObject *parent) :
+    Core::IOutputPane(parent),
+    m_context(new Core::IContext(this))
+{
+    m_outputWidget = new QStackedWidget;
+    QVBoxLayout *outputLayout = new QVBoxLayout;
+    outputLayout->setMargin(0);
+    outputLayout->setSpacing(0);
+
+    QPalette pal;
+    pal.setColor(QPalette::Window,
+                 Utils::creatorTheme()->color(Utils::Theme::InfoBarBackground));
+    pal.setColor(QPalette::WindowText,
+                 Utils::creatorTheme()->color(Utils::Theme::InfoBarText));
+
+    createToolButtons();
+
+    m_model = new TmcResultModel(this);
+    m_listView = new Utils::ListView;
+    m_listView->setModel(m_model);
+    m_listView->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    pal = m_listView->palette();
+    pal.setColor(QPalette::Base, pal.window().color());
+    m_listView->setPalette(pal);
+
+    outputLayout->addWidget(m_listView);
+
+    connect(TMCRunner::instance(), &TMCRunner::testResultReady,
+            this, &TmcOutputPane::addTestResults);
+}
+
+void TmcOutputPane::createToolButtons()
+{
+    m_runAll = new QToolButton(m_listView);
+    m_runAll->setIcon(Utils::Icons::RUN_SMALL_TOOLBAR.icon());
+    m_runAll->setToolTip(tr("Run TMC Tests"));
+    m_runAll->setEnabled(false);
+    connect(m_runAll, &QToolButton::clicked, this, &TmcOutputPane::onRunAllTriggered);
+}
+
+static TmcOutputPane *s_instance = nullptr;
+
+TmcOutputPane *TmcOutputPane::instance()
+{
+    if (!s_instance)
+        s_instance = new TmcOutputPane;
+    return s_instance;
+}
+
+TmcOutputPane::~TmcOutputPane()
+{
+    delete m_listView;
+    if (!m_outputWidget->parent())
+        delete m_outputWidget;
+    s_instance = nullptr;
+}
+
+void TmcOutputPane::onRunAllTriggered()
+{
+    TMCRunner *runner = TMCRunner::instance();
+    runner->runOnActiveProject();
+}
+
+void TmcOutputPane:: addTestResults(const QList<TmcTestResult> &results) {
+    foreach (TmcTestResult r, results) {
+        qDebug() << r.name() << r.isSuccessful() << r.message();
+        m_model->addResult(r);
+    }
+
+    flash();
+    navigateStateChanged();
+}
+
+void TmcOutputPane::clearContents()
+{
+    qDebug() << "contents cleared";
+    m_model->clearResults();
+}
+
+QWidget *TmcOutputPane::outputWidget(QWidget *parent)
+{
+    if (m_outputWidget) {
+        m_outputWidget->setParent(parent);
+    } else {
+        qDebug() << "This should not happen...";
+    }
+    return m_outputWidget;
+}
+
+QList<QWidget *> TmcOutputPane::toolBarWidgets() const
+{
+    return { m_runAll };
+}
+
+QString TmcOutputPane::displayName() const
+{
+    return tr("TMC Results");
+}
+
+int TmcOutputPane::priorityInStatusBar() const
+{
+    return -666;
+}
+
+void TmcOutputPane::visibilityChanged(bool visible)
+{
+    if (visible == m_wasVisibleBefore)
+        return;
+    m_wasVisibleBefore = visible;
+}
+
+void TmcOutputPane::setFocus()
+{
+}
+
+bool TmcOutputPane::hasFocus() const
+{
+    return m_listView->hasFocus();
+}
+
+bool TmcOutputPane::canFocus() const
+{
+    return true;
+}
+
+bool TmcOutputPane::canNavigate() const
+{
+    return false;
+}
+
+bool TmcOutputPane::canNext() const
+{
+    return true;
+}
+
+bool TmcOutputPane::canPrevious() const
+{
+    return true;
+}
+
+void TmcOutputPane::goToNext()
+{
+}
+
+void TmcOutputPane::goToPrev()
+{
+}
+
+void TmcOutputPane::updateSummaryLabel()
+{
+    m_summaryLabel->setText(tr("tmc test results"));
+}

--- a/src/tmcoutputpane.cpp
+++ b/src/tmcoutputpane.cpp
@@ -101,7 +101,8 @@ void TmcOutputPane:: addTestResults(const QList<TmcTestResult> &results) {
         m_model->addResult(r);
     }
 
-    //popup();
+    // Focus on the results pane
+    popup(IOutputPane::Flag(WithFocus));
     flash();
     navigateStateChanged();
 }

--- a/src/tmcoutputpane.h
+++ b/src/tmcoutputpane.h
@@ -12,11 +12,7 @@
 QT_BEGIN_NAMESPACE
 class QAction;
 class QFrame;
-class QKeyEvent;
-class QLabel;
 class QModelIndex;
-class QMenu;
-class QPlainTextEdit;
 class QStackedWidget;
 class QToolButton;
 QT_END_NAMESPACE

--- a/src/tmcoutputpane.h
+++ b/src/tmcoutputpane.h
@@ -1,0 +1,84 @@
+#ifndef TMCOUTPUTPANE_H
+#define TMCOUTPUTPANE_H
+
+#include "tmctestresult.h"
+#include "tmcresultmodel.h"
+
+#include <coreplugin/ioutputpane.h>
+
+#include <utils/itemviews.h>
+#include <utils/treemodel.h>
+
+QT_BEGIN_NAMESPACE
+class QAction;
+class QFrame;
+class QKeyEvent;
+class QLabel;
+class QModelIndex;
+class QMenu;
+class QPlainTextEdit;
+class QStackedWidget;
+class QToolButton;
+QT_END_NAMESPACE
+
+namespace Core {
+class IContext;
+}
+
+class TmcOutputPane : public Core::IOutputPane
+{
+    Q_OBJECT
+public:
+    virtual ~TmcOutputPane();
+    static TmcOutputPane *instance();
+
+    // IOutputPane interface
+    QWidget *outputWidget(QWidget *parent) override;
+    QList<QWidget *> toolBarWidgets() const override;
+    QString displayName() const override;
+    int priorityInStatusBar() const override;
+    void clearContents() override;
+    void visibilityChanged(bool visible) override;
+    void setFocus() override;
+    bool hasFocus() const override;
+    bool canFocus() const override;
+    bool canNavigate() const override;
+    bool canNext() const override;
+    bool canPrevious() const override;
+    void goToNext() override;
+    void goToPrev() override;
+
+    void addTestResults(const QList<TmcTestResult> &results);
+
+private:
+    explicit TmcOutputPane(QObject *parent = 0);
+
+    void onRunAllTriggered();
+    void onRunSelectedTriggered();
+    void enableAllFilter();
+    void filterMenuTriggered(QAction *action);
+
+    void initializeFilterMenu();
+    void updateSummaryLabel();
+    void createToolButtons();
+    void onTestRunStarted();
+    void onTestRunFinished();
+    void onScrollBarRangeChanged(int, int max);
+    void updateRunActions();
+    void onCustomContextMenuRequested(const QPoint &pos);
+    void onCopyItemTriggered(const QModelIndex &idx);
+    void onCopyWholeTriggered();
+    void onSaveWholeTriggered();
+    void toggleOutputStyle();
+
+    QStackedWidget *m_outputWidget;
+    QFrame *m_summaryWidget;
+    QLabel *m_summaryLabel;
+    Utils::ListView *m_listView;
+    TmcResultModel *m_model;
+    Core::IContext *m_context;
+    QToolButton *m_runAll;
+    bool m_wasVisibleBefore = false;
+};
+
+#endif // TMCOUTPUTPANE_H

--- a/src/tmcoutputpane.h
+++ b/src/tmcoutputpane.h
@@ -53,31 +53,17 @@ public:
 private:
     explicit TmcOutputPane(QObject *parent = 0);
 
-    void onRunAllTriggered();
-    void onRunSelectedTriggered();
-    void enableAllFilter();
-    void filterMenuTriggered(QAction *action);
+    void onTMCTriggered();
 
-    void initializeFilterMenu();
-    void updateSummaryLabel();
     void createToolButtons();
-    void onTestRunStarted();
-    void onTestRunFinished();
-    void onScrollBarRangeChanged(int, int max);
     void updateRunActions();
-    void onCustomContextMenuRequested(const QPoint &pos);
-    void onCopyItemTriggered(const QModelIndex &idx);
-    void onCopyWholeTriggered();
-    void onSaveWholeTriggered();
-    void toggleOutputStyle();
 
+    Core::IContext *m_context;
     QStackedWidget *m_outputWidget;
-    QFrame *m_summaryWidget;
-    QLabel *m_summaryLabel;
+    QWidget *m_resultWidget;
     Utils::ListView *m_listView;
     TmcResultModel *m_model;
-    Core::IContext *m_context;
-    QToolButton *m_runAll;
+    QToolButton *m_runTMC;
     bool m_wasVisibleBefore = false;
 };
 

--- a/src/tmcresultmodel.cpp
+++ b/src/tmcresultmodel.cpp
@@ -1,0 +1,80 @@
+#include "tmcresultmodel.h"
+#include "tmctestresult.h"
+
+#include <utils/qtcassert.h>
+#include <QStandardItemModel>
+
+TmcResultModel::TmcResultModel(QObject *parent) : QAbstractItemModel(parent)
+{
+
+}
+
+void TmcResultModel::addResult(const TmcTestResult &result)
+{
+    int i = m_results.count();
+    beginInsertRows(QModelIndex(), i, i);
+    m_results.insert(m_results.end(), result);
+    endInsertRows();
+}
+
+void TmcResultModel::clearResults()
+{
+    int index = 0;
+    int start = 0;
+    while (index < m_results.count()) {
+        while (index < m_results.count()) {
+            ++start;
+            ++index;
+        }
+        if (index == m_results.count())
+            break;
+        while (index < m_results.count())
+            ++index;
+
+        beginRemoveRows(QModelIndex(), start, index - 1);
+        m_results.erase(m_results.begin() + start, m_results.begin() + index);
+
+        endRemoveRows();
+        index = start;
+    }
+}
+
+QModelIndex TmcResultModel::index(int row, int column, const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return QModelIndex();
+    return createIndex(row, column);
+}
+
+QModelIndex TmcResultModel::parent(const QModelIndex &child) const
+{
+    Q_UNUSED(child)
+    return QModelIndex();
+}
+
+int TmcResultModel::rowCount(const QModelIndex &parent) const
+{
+    return parent.isValid() ? 0 : m_results.count();
+}
+
+int TmcResultModel::columnCount(const QModelIndex &parent) const
+{
+    return parent.isValid() ? 0 : 1;
+}
+
+QVariant TmcResultModel::data(const QModelIndex &index, int role) const
+{
+    int row = index.row();
+    if (!index.isValid() || row < 0 || row >= m_results.count() || index.column() != 0)
+        return QVariant();
+
+    return QVariant::fromValue(result(index));
+}
+
+TmcTestResult TmcResultModel::result(const QModelIndex &index) const
+{
+    int row = index.row();
+    if (!index.isValid() || row < 0 || row >= m_results.count())
+        return TmcTestResult();
+    return m_results.at(row);
+}

--- a/src/tmcresultmodel.cpp
+++ b/src/tmcresultmodel.cpp
@@ -15,8 +15,6 @@ void TmcResultModel::addResult(const TmcTestResult &result)
     int i = m_results.count();
     beginInsertRows(QModelIndex(), i, i);
     m_results.insert(m_results.end(), result);
-    qDebug() << "adding " << result.name();
-    qDebug() << "result size " << m_results.count();
     endInsertRows();
 }
 

--- a/src/tmcresultmodel.h
+++ b/src/tmcresultmodel.h
@@ -2,17 +2,19 @@
 #define TMCRESULTMODEL_H
 
 #include <QAbstractItemModel>
+#include <QAbstractListModel>
 
 #include <QIcon>
 
 #include "tmctestresult.h"
 
-class TmcResultModel : public QAbstractItemModel
+using namespace TestMyCode;
+
+class TmcResultModel : public QAbstractListModel
 {
     Q_OBJECT
-
 public:
-    explicit TmcResultModel(QObject *parent);
+    explicit TmcResultModel(QObject *parent = nullptr);
 
     // QAbstractItemModel
     QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;

--- a/src/tmcresultmodel.h
+++ b/src/tmcresultmodel.h
@@ -1,0 +1,35 @@
+#ifndef TMCRESULTMODEL_H
+#define TMCRESULTMODEL_H
+
+#include <QAbstractItemModel>
+
+#include <QIcon>
+
+#include "tmctestresult.h"
+
+class TmcResultModel : public QAbstractItemModel
+{
+    Q_OBJECT
+
+public:
+    explicit TmcResultModel(QObject *parent);
+
+    // QAbstractItemModel
+    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
+    QModelIndex parent(const QModelIndex &child) const override;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    TmcTestResult result(const QModelIndex &index) const;
+
+    QList<TmcTestResult> results() const;
+    void addResult(const TmcTestResult &result);
+    void addResults(const QList<TmcTestResult> &results);
+    void clearResults();
+
+private:
+
+    QList<TmcTestResult> m_results;
+};
+
+#endif // TMCRESULTMODEL_H

--- a/src/tmcrunner.cpp
+++ b/src/tmcrunner.cpp
@@ -1,0 +1,153 @@
+#include "tmcrunner.h"
+#include "tmcoutputpane.h"
+#include "tmctestresult.h"
+
+#include <coreplugin/icore.h>
+#include <coreplugin/icontext.h>
+#include <coreplugin/progressmanager/futureprogress.h>
+#include <coreplugin/progressmanager/progressmanager.h>
+
+#include <projectexplorer/projectexplorersettings.h>
+#include <projectexplorer/projectexplorer.h>
+#include <projectexplorer/buildmanager.h>
+#include <projectexplorer/target.h>
+#include <projectexplorer/project.h>
+#include <projectexplorer/session.h>
+
+#include <utils/outputformat.h>
+#include <utils/runextensions.h>
+#include <utils/hostosinfo.h>
+#include <utils/fileutils.h>
+#include <utils/environment.h>
+#include <utils/shellcommand.h>
+
+#include <QProcessEnvironment>
+#include <QFileInfo>
+#include <QFuture>
+#include <QFutureInterface>
+#include <QTime>
+
+#include <QMessageBox>
+#include <QList>
+
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QJsonDocument>
+
+static TMCRunner *s_instance = nullptr;
+
+TMCRunner *TMCRunner::instance()
+{
+    if (!s_instance)
+        s_instance = new TMCRunner;
+    return s_instance;
+}
+
+TMCRunner::TMCRunner(QObject *parent) :
+    QObject(parent)
+{
+
+}
+
+TMCRunner::~TMCRunner()
+{
+    s_instance = nullptr;
+}
+
+void TMCRunner::runOnActiveProject()
+{
+    ProjectExplorer::Project *project = ProjectExplorer::SessionManager::startupProject();
+    if (!project) {
+        QMessageBox::information(Core::ICore::mainWindow(), tr("No project"), tr("No active project"));
+        return;
+    }
+    const Utils::FileName project_path = project->projectFilePath().parentDir();
+    launchTmcCLI(project_path);
+}
+
+void TMCRunner::launchTmcCLI(const Utils::FileName &workingDirectory)
+{
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    QString tmc_cli = env.value("TMC_CLI", "/opt/tmc_cli.jar");
+    QString dir = workingDirectory.toString();
+
+    QString testOutput = dir + "/out.txt";
+    QStringList arguments;
+    arguments << "-jar" << tmc_cli;
+    arguments << "run-tests";
+    arguments << "--exercisePath" << dir;
+    arguments << "--outputPath" << testOutput;
+    QMessageBox::information(Core::ICore::mainWindow(), tr("launching"), tr("%1").arg(arguments.join(QString(" "))));
+    // TODO: make work in windows
+    const Utils::FileName java = Utils::FileName().fromString("/usr/bin/java");
+
+    Utils::ShellCommand command(dir, env);
+
+    Utils::SynchronousProcessResponse response
+         = command.runCommand(java, arguments, 1500, dir, Utils::defaultExitCodeInterpreter);
+
+    QMessageBox::information(Core::ICore::mainWindow(), tr("TMC output"), tr("%1").arg(response.allOutput()));
+
+    QList<TmcTestResult> output = readTMCOutput(testOutput);
+    emit testResultReady(output);
+}
+
+/*
+   TMC CLI output format is JSON,
+   where compiler / stacktrace output is in integers representing characters:
+
+  {
+    "status": "COMPILE_FAILED",
+    "testResults": [],
+    "logs": {
+      "compiler_output": [
+        [109,97,107,101,58,32,42,42,42,32,78 ...]
+    }
+  }
+
+*/
+QList<TmcTestResult> TMCRunner::readTMCOutput(const QString &testOutput)
+{
+    QFile file(testOutput);
+    if(!file.open(QIODevice::ReadOnly)) {
+        QMessageBox::information(0, "error", file.errorString());
+    }
+
+    QByteArray rawData = file.readAll();
+    file.close();
+
+    QJsonDocument doc(QJsonDocument::fromJson(rawData));
+
+    const QJsonObject json = doc.object();
+    const QString status = json["status"].toString();
+    const QJsonObject logs = json["logs"].toObject();
+
+    // Convert integers back to a string
+    const QJsonArray compiler_output = logs["compiler_output"].toArray();
+    QString compiler_output_str;
+    foreach (QJsonValue character, compiler_output) {
+        compiler_output_str.append(character.toInt());
+    }
+
+    QMessageBox::information(Core::ICore::mainWindow(), tr("%1").arg(status), tr("%1").arg(compiler_output_str));
+    QList<TmcTestResult> results;
+
+    const QJsonArray testResults = json["testResults"].toArray();
+    foreach (QJsonValue result, testResults) {
+        QJsonObject r = result.toObject();
+        TmcTestResult tmcResult(r["name"].toString());
+        tmcResult.setSuccess(r["successful"].toBool());
+        tmcResult.setMessage(r["message"].toString());
+        tmcResult.setException(r["exception"].toString());
+
+        QList<QString> points;
+        QJsonArray points_array = r["points"].toArray();
+        foreach (QJsonValue point, points_array) {
+            points.append(point.toString());
+        }
+        tmcResult.setPoints(points);
+        results.append(tmcResult);
+    }
+
+    return results;
+}

--- a/src/tmcrunner.h
+++ b/src/tmcrunner.h
@@ -12,6 +12,8 @@
 #include <QObject>
 #include <QProcess>
 
+using namespace TestMyCode;
+
 namespace ProjectExplorer {
 class Project;
 }

--- a/src/tmcrunner.h
+++ b/src/tmcrunner.h
@@ -1,0 +1,43 @@
+#ifndef TMCRUNNER_H
+#define TMCRUNNER_H
+
+#include "tmctestresult.h"
+
+#include <projectexplorer/projectexplorer.h>
+#include <projectexplorer/project.h>
+#include <projectexplorer/session.h>
+#include <projectexplorer/target.h>
+
+#include <QFutureWatcher>
+#include <QObject>
+#include <QProcess>
+
+namespace ProjectExplorer {
+class Project;
+}
+
+class TMCRunner : public QObject
+{
+    Q_OBJECT
+
+public:
+    static TMCRunner* instance();
+    ~TMCRunner();
+
+    bool isTMCRunning() const { return m_executingTMC; }
+    void runOnActiveProject();
+
+signals:
+    void testResultReady(const QList<TmcTestResult> &result);
+
+private:
+    void launchTmcCLI(const Utils::FileName &workingDirectory);
+    QList<TmcTestResult> readTMCOutput(const QString &testOutput);
+    void onFinished();
+    bool m_executingTMC;
+
+    explicit TMCRunner(QObject *parent = 0);
+
+};
+
+#endif // TMCRUNNER_H

--- a/src/tmctestresult.cpp
+++ b/src/tmctestresult.cpp
@@ -1,5 +1,7 @@
 #include "tmctestresult.h"
 
+using namespace TestMyCode;
+
 TmcTestResult::TmcTestResult()
 {
 }
@@ -8,5 +10,5 @@ TmcTestResult::TmcTestResult()
 TmcTestResult::TmcTestResult(const QString &name)
     : m_name(name)
 {
-
 }
+

--- a/src/tmctestresult.cpp
+++ b/src/tmctestresult.cpp
@@ -1,0 +1,12 @@
+#include "tmctestresult.h"
+
+TmcTestResult::TmcTestResult()
+{
+}
+
+
+TmcTestResult::TmcTestResult(const QString &name)
+    : m_name(name)
+{
+
+}

--- a/src/tmctestresult.h
+++ b/src/tmctestresult.h
@@ -5,6 +5,8 @@
 #include <QList>
 #include <QString>
 
+namespace TestMyCode {
+
 class TmcTestResult
 {
 public:
@@ -33,7 +35,8 @@ private:
     QString m_exception;
 
 };
+}
 
-Q_DECLARE_METATYPE(TmcTestResult)
+Q_DECLARE_METATYPE(TestMyCode::TmcTestResult)
 #endif // TMCTESTRESULT_H
 

--- a/src/tmctestresult.h
+++ b/src/tmctestresult.h
@@ -1,0 +1,39 @@
+#ifndef TMCTESTRESULT_H
+#define TMCTESTRESULT_H
+
+#include <QMetaType>
+#include <QList>
+#include <QString>
+
+class TmcTestResult
+{
+public:
+    TmcTestResult();
+    explicit TmcTestResult(const QString &name);
+
+    virtual ~TmcTestResult() {}
+
+    QString name() const { return m_name; }
+    bool isSuccessful() const { return m_successful; }
+    QString message() const { return m_message; }
+    QList<QString> points() const { return m_points; }
+    QString exception() const { return m_exception; }
+
+    void setMessage(const QString &message) { m_message = message; }
+    void setSuccess(const bool &successful) { m_successful = successful; }
+    void setPoints(QList<QString> points) { m_points = points; }
+    void setException(const QString &ex) { m_exception = ex; }
+
+private:
+
+    QString m_name;
+    bool m_successful;
+    QString m_message;
+    QList<QString> m_points;
+    QString m_exception;
+
+};
+
+Q_DECLARE_METATYPE(TmcTestResult)
+#endif // TMCTESTRESULT_H
+

--- a/testmycode.pro
+++ b/testmycode.pro
@@ -12,11 +12,21 @@ test {
         test/testmycode_tests.cpp
 } else {
 
-SOURCES += src/testmycode.cpp
+SOURCES += src/testmycode.cpp \
+           src/tmcclient.cpp \
+           src/tmcoutputpane.cpp \
+           src/tmcrunner.cpp \
+           src/tmctestresult.cpp \
+           src/tmcresultmodel.cpp
 
 HEADERS += src/testmycode.h \
         src/testmycode_global.h \
-        src/testmycodeconstants.h
+        src/testmycodeconstants.h \
+        src/tmcclient.h \
+        src/tmcoutputpane.h \
+        src/tmcrunner.h \
+        src/tmctestresult.h \
+        src/tmcresultmodel.h
 
 # Qt Creator linking
 
@@ -82,10 +92,3 @@ message("Plugin output path: $$DESTDIR")
 FORMS += \
     loginscreen.ui
 
-STATECHARTS +=
-
-HEADERS += \
-    src/tmcclient.h
-
-SOURCES += \
-    src/tmcclient.cpp


### PR DESCRIPTION
After TMC CLI execution, results are read into a TmcResult model and displayed in QListView in a separate "TMC Results" pane. Textual form only, for now.