### PR TITLE
Auth refactor

### DIFF
--- a/lib/tmcclient/tmcclient.cpp
+++ b/lib/tmcclient/tmcclient.cpp
@@ -76,6 +76,7 @@ void TmcClient::authenticate(QString username, QString password)
         emit TMCError(QString("Login failed: "
                               "no client id/secret available"));
         emit authenticationFinished("");
+        return;
     }
 
     QUrl url("https://tmc.mooc.fi/oauth/token");

--- a/lib/tmcclient/tmcclient.cpp
+++ b/lib/tmcclient/tmcclient.cpp
@@ -3,7 +3,6 @@
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QJsonArray>
-#include <QSettings>
 #include <QBuffer>
 
 #include <quazip/JlCompress.h>
@@ -15,48 +14,34 @@ TmcClient::TmcClient(QObject *parent) : QObject(parent)
 {
 }
 
-void TmcClient::authenticate(QString username, QString password, bool savePassword)
-{
-    QString client_id = "8355b4a75a4191edfedeae7b074571278fd4987d4234c01569678b9ad11f526d";
-    QString client_secret = "c2b1176a6189ceaa16cd51f805ef20ea6c993d36fdb76aa873ac35471d2df4f1";
-    QString username_ = username;
-    QString password_ = password;
-    QString grant_type = "password";
-
-    QSettings settings("TestMyQt", "TMC");
-    settings.setValue("username", username);
-    if (savePassword) {
-        settings.setValue("password", password);
-        settings.setValue("savePasswordChecked", "true");
-    } else {
-        settings.setValue("password", "");
-        settings.setValue("savePasswordChecked", "false");
-    }
-    settings.deleteLater();
-
-    QUrl url("https://tmc.mooc.fi/oauth/token");
-
-    QUrlQuery params;
-    params.addQueryItem("client_id", client_id);
-    params.addQueryItem("client_secret", client_secret);
-    params.addQueryItem("username", username_);
-    params.addQueryItem("password", password_);
-    params.addQueryItem("grant_type", grant_type);
-
-    QNetworkRequest request(url);
-
-    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
-
-    QNetworkReply *reply = manager->post(request, params.toString(QUrl::FullyEncoded).toUtf8());
-
-    connect(reply, &QNetworkReply::finished, this, [=](){
-        authenticationFinished(reply);
-    });
-}
-
 void TmcClient::setNetworkManager(QNetworkAccessManager *m)
 {
     manager = m;
+}
+
+void TmcClient::setAccessToken(QString token)
+{
+    accessToken = token;
+}
+
+void TmcClient::setClientId(QString id)
+{
+    clientId = id;
+}
+
+void TmcClient::setClientSecret(QString secret)
+{
+    clientSecret = secret;
+}
+
+bool TmcClient::isAuthorized()
+{
+    return !(clientId.isEmpty() || clientSecret.isEmpty());
+}
+
+bool TmcClient::isAuthenticated()
+{
+    return !accessToken.isEmpty();
 }
 
 QNetworkRequest TmcClient::buildRequest(QUrl url)
@@ -72,6 +57,46 @@ QNetworkReply* TmcClient::doGet(QUrl url)
     QNetworkRequest request = buildRequest(url);
     QNetworkReply *reply = manager->get(request);
     return reply;
+}
+
+void TmcClient::authorize()
+{
+    QUrl url("https://tmc.mooc.fi/api/v8/application/qtcreator_plugin/credentials.json");
+    QNetworkReply *reply = doGet(url);
+
+    connect(reply, &QNetworkReply::finished, this, [=](){
+        authorizationReplyFinished(reply);
+    });
+}
+
+void TmcClient::authenticate(QString username, QString password)
+{
+
+    if (!isAuthorized()) {
+        emit TMCError(QString("Login failed: "
+                              "no client id/secret available"));
+        emit authenticationFinished("");
+    }
+
+    QUrl url("https://tmc.mooc.fi/oauth/token");
+
+    QString grantType = "password";
+    QUrlQuery params;
+    params.addQueryItem("client_id", clientId);
+    params.addQueryItem("client_secret", clientSecret);
+    params.addQueryItem("username", username);
+    params.addQueryItem("password", password);
+    params.addQueryItem("grant_type", grantType);
+
+    QNetworkRequest request(url);
+
+    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
+
+    QNetworkReply *reply = manager->post(request, params.toString(QUrl::FullyEncoded).toUtf8());
+
+    connect(reply, &QNetworkReply::finished, this, [=](){
+        authenticationReplyFinished(reply);
+    });
 }
 
 QNetworkReply* TmcClient::getExerciseZip(Exercise *ex)
@@ -108,15 +133,28 @@ void TmcClient::getUserInfo()
     });
 }
 
-void TmcClient::authenticationFinished(QNetworkReply *reply)
+void TmcClient::authorizationReplyFinished(QNetworkReply *reply)
+{
+    if (reply->error()) {
+        emit TMCError(QString("Client authorization failed: %1: %2")
+                      .arg(reply->errorString(), reply->error()));
+        reply->deleteLater();
+        return;
+    }
+
+    QJsonObject json = QJsonDocument::fromJson(reply->readAll()).object();
+    setClientId(json["application_id"].toString());
+    setClientSecret(json["secret"].toString());
+
+    emit authorizationFinished(clientId, clientSecret);
+}
+
+void TmcClient::authenticationReplyFinished(QNetworkReply *reply)
 {
     if (reply->error()) {
         emit TMCError(QString("Login failed: %1: %2")
                       .arg(reply->errorString(), reply->error()));
-        QSettings settings("TestMyQt", "TMC");
-        settings.setValue("username", "");
-        settings.setValue("password", "");
-        settings.deleteLater();
+        emit authenticationFinished("");
         reply->deleteLater();
         return;
     }
@@ -132,7 +170,7 @@ void TmcClient::authenticationFinished(QNetworkReply *reply)
     accessToken = name["access_token"].toString();
     qDebug() << accessToken;
 
-    emit loginFinished();
+    emit authenticationFinished(accessToken);
     reply->deleteLater();
 }
 

--- a/lib/tmcclient/tmcclient.h
+++ b/lib/tmcclient/tmcclient.h
@@ -19,19 +19,29 @@ public:
     explicit TmcClient(QObject *parent = 0);
 
     void setNetworkManager(QNetworkAccessManager *m);
-    void authenticate(QString username, QString password, bool savePassword);
+    void setAccessToken(QString token);
+    void setClientId(QString id);
+    void setClientSecret(QString secret);
+
+    void authorize();
+    void authenticate(QString username, QString password);
     void getUserInfo();
     void getExerciseList(Course *course);
     QNetworkReply* getExerciseZip(Exercise *ex);
 
+    bool isAuthorized();
+    bool isAuthenticated();
+
 signals:
     void TMCError(QString errorString);
-    void loginFinished();
+    void authorizationFinished(QString clientId, QString clientSecret);
+    void authenticationFinished(QString accessToken);
     void exerciseListReady(Course *course);
     void exerciseZipReady(Exercise *ex);
 
-public slots:
-    void authenticationFinished (QNetworkReply *reply);
+private slots:
+    void authorizationReplyFinished (QNetworkReply *reply);
+    void authenticationReplyFinished (QNetworkReply *reply);
     void exerciseListReplyFinished (QNetworkReply *reply, Course *course);
     void exerciseZipReplyFinished (QNetworkReply *reply, Exercise *ex);
 
@@ -40,6 +50,8 @@ private:
     QNetworkReply* doGet(QUrl url);
     QNetworkAccessManager *manager;
     QString accessToken;
+    QString clientId;
+    QString clientSecret;
 
 };
 

--- a/src/testmycode.cpp
+++ b/src/testmycode.cpp
@@ -118,7 +118,7 @@ bool TestMyCode::initialize(const QStringList &arguments, QString *errorString)
     // Signal-Slot for login window
     QObject::connect(login->cancelbutton, SIGNAL(clicked(bool)), this, SLOT(on_login_cancelbutton_clicked()));
     QObject::connect(login->loginbutton, SIGNAL(clicked(bool)), this, SLOT(on_login_loginbutton_clicked()));
-    connect(&tmcClient, &TmcClient::loginFinished, this, &TestMyCode::on_login_cancelbutton_clicked);
+    connect(&tmcClient, &TmcClient::authorizationFinished, this, &TestMyCode::on_login_cancelbutton_clicked);
     connect(&tmcClient, &TmcClient::exerciseListReady, this, &TestMyCode::refreshDownloadList);
     connect(&tmcClient, &TmcClient::exerciseZipReady, this, &TestMyCode::openProject);
     connect(&tmcClient, &TmcClient::TMCError, this, &TestMyCode::displayTMCError);
@@ -208,7 +208,7 @@ void TestMyCode::on_login_loginbutton_clicked()
     QString username = login->usernameinput->text();
     QString password = login->passwordinput->text();
     bool savePassword = login->savepasswordbox->isChecked();
-    tmcClient.authenticate(username, password, savePassword);
+    tmcClient.authenticate(username, password);
 }
 
 void TestMyCode::on_download_cancelbutton_clicked()

--- a/src/testmycode.cpp
+++ b/src/testmycode.cpp
@@ -75,21 +75,30 @@ bool TestMyCode::initialize(const QStringList &arguments, QString *errorString)
     auto downloadAction = new QAction(tr("Download"), this);
     Core::Command *downloadCmd = Core::ActionManager::registerAction(downloadAction, Constants::DOWNLOAD_ACTION_ID,
                                                                      Core::Context(Core::Constants::C_GLOBAL));
+
+    auto logoutAction = new QAction(tr("Logout"), this);
+    Core::Command *logoutCmd = Core::ActionManager::registerAction(logoutAction, Constants::LOGOUT_ACTION_ID,
+                                                                     Core::Context(Core::Constants::C_GLOBAL));
     // Shortcut
     tmcCmd->setDefaultKeySequence(QKeySequence(tr("Alt+Shift+T")));
     loginCmd->setDefaultKeySequence(QKeySequence(tr("Alt+L")));
     downloadCmd->setDefaultKeySequence(QKeySequence(tr("Alt+D")));
+    logoutCmd->setDefaultKeySequence(QKeySequence(tr("Alt+Shift+L")));
+
+    // Connect to trigger to a function
     connect(loginAction, &QAction::triggered, this, &TestMyCode::showLoginWidget);
     connect(tmcAction, &QAction::triggered, this, &TestMyCode::runTMC);
     connect(downloadAction, &QAction::triggered, this, &TestMyCode::showDownloadWidget);
+    connect(logoutAction, &QAction::triggered, this, &TestMyCode::clearCredentials);
 
+    // Create context menu with actions
     Core::ActionContainer *menu = Core::ActionManager::createMenu(Constants::MENU_ID);
-
     menu->menu()->setTitle(tr("TestMyCode"));
     Core::ActionManager::actionContainer(Core::Constants::M_TOOLS)->addMenu(menu);
     menu->addAction(tmcCmd);
     menu->addAction(loginCmd);
     menu->addAction(downloadCmd);
+    menu->addAction(logoutCmd);
 
     // Add TestMyCode between Tools and Window in the upper menu
     auto tools_menu = Core::ActionManager::actionContainer(Core::Constants::M_WINDOW);
@@ -109,6 +118,11 @@ bool TestMyCode::initialize(const QStringList &arguments, QString *errorString)
 
     // Create settings
     QSettings settings("TestMyQt", "TMC");
+
+    tmcClient.setAccessToken(settings.value("accessToken", "").toString());
+    tmcClient.setClientId(settings.value("clientId", "").toString());
+    tmcClient.setClientSecret(settings.value("clientSecret", "").toString());
+
     login->usernameinput->setText(settings.value("username", "").toString());
     login->passwordinput->setText(settings.value("password", "").toString());
     if (settings.value("savePasswordChecked").toString() == "true")
@@ -116,20 +130,28 @@ bool TestMyCode::initialize(const QStringList &arguments, QString *errorString)
     settings.deleteLater();
 
     // Signal-Slot for login window
-    QObject::connect(login->cancelbutton, SIGNAL(clicked(bool)), this, SLOT(on_login_cancelbutton_clicked()));
-    QObject::connect(login->loginbutton, SIGNAL(clicked(bool)), this, SLOT(on_login_loginbutton_clicked()));
-    connect(&tmcClient, &TmcClient::authorizationFinished, this, &TestMyCode::on_login_cancelbutton_clicked);
+    connect(login->cancelbutton, &QPushButton::clicked, this, &TestMyCode::onLoginCancelClicked);
+    connect(login->loginbutton, &QPushButton::clicked, this, &TestMyCode::onLoginClicked);
+
+    // TmcClient
+    connect(&tmcClient, &TmcClient::authorizationFinished, this, &TestMyCode::handleAuthResponse);
+    connect(&tmcClient, &TmcClient::authenticationFinished, this, &TestMyCode::handleLoginResponse);
     connect(&tmcClient, &TmcClient::exerciseListReady, this, &TestMyCode::refreshDownloadList);
     connect(&tmcClient, &TmcClient::exerciseZipReady, this, &TestMyCode::openProject);
     connect(&tmcClient, &TmcClient::TMCError, this, &TestMyCode::displayTMCError);
 
-
     // Signal-Slot for download window
-    QObject::connect(downloadform->cancelbutton, SIGNAL(clicked(bool)), this, SLOT(on_download_cancelbutton_clicked()));
-    QObject::connect(downloadform->okbutton, SIGNAL(clicked(bool)), this, SLOT(on_download_okbutton_clicked()));
+    connect(downloadform->cancelbutton, &QPushButton::clicked, this, &TestMyCode::onDownloadCancelClicked);
+    connect(downloadform->okbutton, &QPushButton::clicked, this, &TestMyCode::onDownloadOkClicked);
 
     QNetworkAccessManager *m = new QNetworkAccessManager;
     tmcClient.setNetworkManager(m);
+
+    // TODO: authorization happens at plugin creation time, but this could be done
+    // when a server is activated in preferences
+    if (!tmcClient.isAuthorized()) {
+        tmcClient.authorize();
+    }
 
     return true;
 }
@@ -186,7 +208,7 @@ void TestMyCode::openProject(Exercise *ex)
 
 void TestMyCode::displayTMCError(QString errorText)
 {
-    QMessageBox::critical(NULL, "TMC", errorText, QMessageBox::Ok);
+    QMessageBox::critical(nullptr, "TMC", errorText, QMessageBox::Ok);
 }
 
 void TestMyCode::setDefaultCourse()
@@ -198,20 +220,70 @@ void TestMyCode::setDefaultCourse()
     tmcClient.getExerciseList(course);
 }
 
-void TestMyCode::on_login_cancelbutton_clicked()
+void TestMyCode::onLoginCancelClicked()
 {
     loginWidget->close();
 }
 
-void TestMyCode::on_login_loginbutton_clicked()
+void TestMyCode::onLoginClicked()
 {
     QString username = login->usernameinput->text();
     QString password = login->passwordinput->text();
     bool savePassword = login->savepasswordbox->isChecked();
+
     tmcClient.authenticate(username, password);
+
+    QSettings settings("TestMyQt", "TMC");
+    settings.setValue("username", username);
+    if (savePassword) {
+        settings.setValue("password", password);
+        settings.setValue("savePasswordChecked", "true");
+    } else {
+        settings.setValue("password", "");
+        settings.setValue("savePasswordChecked", "false");
+    }
+    settings.deleteLater();
 }
 
-void TestMyCode::on_download_cancelbutton_clicked()
+void TestMyCode::handleAuthResponse(QString clientId, QString clientSecret)
+{
+    QSettings settings("TestMyQt", "TMC");
+    settings.setValue("clientId", clientId);
+    settings.setValue("clientSecret", clientSecret);
+    settings.deleteLater();
+}
+
+void TestMyCode::handleLoginResponse(QString accessToken)
+{
+    QSettings settings("TestMyQt", "TMC");
+    // We did not receive any token, credentials were not valid
+    if (accessToken == "") {
+        settings.setValue("username", "");
+        settings.setValue("password", "");
+    } else {
+        settings.setValue("accessToken", accessToken);
+        loginWidget->close();
+    }
+
+    settings.deleteLater();
+}
+
+void TestMyCode::clearCredentials()
+{
+    QSettings settings("TestMyQt", "TMC");
+    settings.setValue("username", "");
+    settings.setValue("password", "");
+
+    settings.setValue("clientId", "");
+    settings.setValue("clientSecret", "");
+    settings.setValue("accessToken", "");
+    settings.deleteLater();
+    tmcClient.setAccessToken("");
+    tmcClient.setClientId("");
+    tmcClient.setClientSecret("");
+}
+
+void TestMyCode::onDownloadCancelClicked()
 {
     downloadWidget->close();
 }
@@ -229,7 +301,7 @@ QString TestMyCode::askSaveLocation()
     return saveDirectory;
 }
 
-void TestMyCode::on_download_okbutton_clicked()
+void TestMyCode::onDownloadOkClicked()
 {
     auto exerciseList = downloadform->exerciselist;
     qDebug() << "There are " << exerciseList->count() << "exercises to be loaded.";

--- a/src/testmycode.h
+++ b/src/testmycode.h
@@ -6,26 +6,9 @@
 #include "downloadpanel.h"
 
 #include <extensionsystem/iplugin.h>
-#include <QWidget>
 
-#include <projectexplorer/project.h>
-#include <projectexplorer/projectexplorer.h>
-#include <projectexplorer/session.h>
-#include <projectexplorer/target.h>
-
-#include <extensionsystem/iplugin.h>
-#include <utils/hostosinfo.h>
-#include <utils/fileutils.h>
-
-#include <QAction>
-#include <QMessageBox>
-#include <QMainWindow>
-#include <QMenu>
 #include <QObject>
 #include <QString>
-#include <QCoreApplication>
-#include <QProcessEnvironment>
-#include <QFileInfo>
 
 namespace TestMyCodePlugin {
 namespace Internal {
@@ -45,11 +28,11 @@ public:
 
 private slots:
     // Loginform
-    void on_login_cancelbutton_clicked();
-    void on_login_loginbutton_clicked();
+    void onLoginCancelClicked();
+    void onLoginClicked();
     // Downloadform
-    void on_download_cancelbutton_clicked();
-    void on_download_okbutton_clicked();
+    void onDownloadCancelClicked();
+    void onDownloadOkClicked();
     void refreshDownloadList();
 
 private:
@@ -71,6 +54,10 @@ private:
     void openProject(Exercise *ex);
     void displayTMCError(QString errorText);
     QString askSaveLocation();
+    void clearCredentials();
+    void handleLoginResponse(QString accessToken);
+    void handleAuthResponse(QString clientId, QString clientSecret);
+
     // ...
     DownloadPanel *downloadPanel;
 };

--- a/src/testmycodeconstants.h
+++ b/src/testmycodeconstants.h
@@ -5,7 +5,8 @@ namespace Constants {
 
 const char TMC_ACTION_ID[] = "TestMyCodePlugin.Action.TMC";
 const char LOGIN_ACTION_ID[] = "TestMyCodePlugin.Action.Login";
-const char DOWNLOAD_ACTION_ID[] = "TestMyCdoePlugin.Action.Download";
+const char DOWNLOAD_ACTION_ID[] = "TestMyCodePlugin.Action.Download";
+const char LOGOUT_ACTION_ID[] = "TestMyCodePlugin.Action.Logout";
 
 const char MENU_ID[] = "TestMyCodePlugin.Menu";
 


### PR DESCRIPTION
- Both client authorization and authentication values are now saved as QSettings and fetched from TMC
- Added logout to clear all the tokens
- Added authorization test

I do not know where authorization should happen when the values are not available, at startup or when we actually need them to make requests? If we cannot retrieve the client id/secret that probably means the TMC address is incorrect in the settings. That could pop up the settings window for the user. Similar thing with the access token.
